### PR TITLE
Dont eval out of owin

### DIFF
--- a/R/bivariate.density.R
+++ b/R/bivariate.density.R
@@ -280,6 +280,7 @@ bivariate.density <- function(pp,h0,hp=NULL,adapt=FALSE,resolution=128,gamma.sca
 		h.spec <- h0*pmin(pspec,trim*gspd)/gamma
 		h.hypo <- h0*im(matrix(pmin(as.vector(as.matrix(pilot.density^(-0.5))),trim*gspd),resolution,resolution)/gamma,xcol=pilot.density$xcol,yrow=pilot.density$yrow)
 		h.hypo.mat <- as.matrix(h.hypo)
+		h.hypo.vec <- as.numeric(t(h.hypo.mat))
 
 		if(!is.null(davies.baddeley)){
 			db <- checkdb(davies.baddeley)
@@ -308,7 +309,7 @@ bivariate.density <- function(pp,h0,hp=NULL,adapt=FALSE,resolution=128,gamma.sca
 			qhz <- rep(NA,resolution^2)
 			if(verbose) pb <- txtProgressBar(0,nrow(evalxy))
 			for(i in 1:nrow(evalxy)){
-				ht <- h.hypo.mat[which(pilot.density$yrow==evalxy[i,2]),which(pilot.density$xcol==evalxy[i,1])]
+				ht <- h.hypo.vec[i]
 				if(is.na(ht)) next
 				gxy <- kernel2d(evalxy[!notin,1]-evalxy[i,1], evalxy[!notin,2]-evalxy[i,2], ht)
 		    qhz[i] <- dintegral(gxy, pilot.density$xstep, pilot.density$ystep)


### PR DESCRIPTION
This gives a modest speedup. Basically don't use points outside the OWIN to evaluate (or center) densities on. We override them with NA at the end anyway, so mayaswell ignore them completely, as it doesn't really complicate the code at all (just iterate over the ones in region instead of the entire grid).

I'll look at whether h.hypo* can be cleaned up a bit. It's a little convoluted at moment: matrix->vector->matrix->im->matrix->vector :)

EDIT: typo fixed, confirmed identical to previous version.