### PR TITLE
use the package version in zzz.R

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -3,6 +3,6 @@
 	s2 <- "  / ___// _ \\/ _  \\/ __ \\/ __ \\        \n"
 	s3 <- "  \\__ \\/ ___/ __  /  ___/  ___/        \n"
 	s4 <- " ___/ / /  / / / / /\\ \\/ /\\ \\          \n"
-	s5 <- "/____/_/  /_/ /_/_/  \\__/  \\_\\   v2.0-04\n\n"
+	s5 <- paste0("/____/_/  /_/ /_/_/  \\__/  \\_\\   v", packageVersion('sparr'), "\n\n")
 	packageStartupMessage(paste("\n\nWelcome to\n",s1,s2,s3,s4,s5,"*type help(\"sparr\") for an overview\n",sep=""),appendLF=TRUE)
 } #\n*type vignette(\"sparr2\") to access the accompanying article [unimplemented]\n*type citation(\"sparr2\") for how to cite use of this package\n"


### PR DESCRIPTION
Fairly self-explanatory. Means one less place to manually mess with things, and thus one less thing to screw up on release :)

The version and date are also used in the sparr-package.R/Rd documentation. Most packages don't do that (mostly as it's a pain to update it, users don't care so much, and you can use packageVersion/sessionInfo to get it anyway) so I'd usually recommend removing.

However, if you want it there, I can look to see whether we can use a roxygen template to generate it. It might be a fun thing for me to learn how to do I guess, so let me know if you want me to attempt.