### PR TITLE
Fastest fourier transform in the west

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,6 +8,7 @@ Maintainer: Tilman M. Davies <tdavies@maths.otago.ac.nz>
 Description: Provides functions to estimate kernel-smoothed spatial (and spatio-temporal in future) relative risk functions and perform subsequent inference.
 Depends: R (>= 2.10.1), spatstat
 Imports: spatstat.utils, doParallel, parallel, foreach, ks
+Suggests: fftwtools (>= 0.9.8)
 License: GPL (>= 2)
 LazyLoad: yes
 NeedsCompilation: no

--- a/R/adens.R
+++ b/R/adens.R
@@ -65,7 +65,9 @@ adens <- function(x,bwim,bwpts,resolution,edge,diggle,weights,intensity,hstep,qs
   
   if(edge&&diggle) digw <- 1/safelookup(edg,x,warn=FALSE)
   else digw <- rep(1,n)
-  
+
+  use_fftw <- fftw_available()
+
   weights <- weights*digw
   imlist <- point_image_by_bw(hu, hc, nearest.raster.point(x$x,x$y,w=WM), weights, WM)
 
@@ -78,8 +80,8 @@ adens <- function(x,bwim,bwpts,resolution,edge,diggle,weights,intensity,hstep,qs
   if(verbose) pb <- txtProgressBar(0,U)
   for(i in 1:U){
     fK <- kernel2d_fft(hu[i], WM$xstep, WM$ystep, resolution)
-    fZ <- fft2d(imlist[[i]])
-    sm <- fft2d(fZ*fK,inverse=TRUE)/len.pad
+    fZ <- fft2d(imlist[[i]],fftw=use_fftw)
+    sm <- fft2d(fZ*fK,inverse=TRUE,fftw=use_fftw)/len.pad
     smo <- Re(sm[resseq,resseq])
 
     resultlist[[i]] <- im(smo,xcol.pad,yrow.pad)

--- a/R/adens.R
+++ b/R/adens.R
@@ -78,8 +78,8 @@ adens <- function(x,bwim,bwpts,resolution,edge,diggle,weights,intensity,hstep,qs
   if(verbose) pb <- txtProgressBar(0,U)
   for(i in 1:U){
     fK <- kernel2d_fft(hu[i], WM$xstep, WM$ystep, resolution)
-    fZ <- fft(imlist[[i]])
-    sm <- fft(fZ*fK,inverse=TRUE)/len.pad
+    fZ <- fft2d(imlist[[i]])
+    sm <- fft2d(fZ*fK,inverse=TRUE)/len.pad
     smo <- Re(sm[resseq,resseq])
 
     resultlist[[i]] <- im(smo,xcol.pad,yrow.pad)

--- a/R/edgeh.R
+++ b/R/edgeh.R
@@ -13,21 +13,23 @@ edgeh <- function(bwim,pres,tres,step,W,verbose=FALSE){
   hypocen <- hypoQ[-length(hypoQ)]+diff(hypoQ/2)
   corrQ <- as.numeric(cut(as.vector(as.matrix(hfp)),breaks=hypoQ,include.lowest=TRUE))
   if(pres<tres) corrQ[is.na(corrQ)] <- 1
-  
+
+  use_fftw <- fftw_available()
+
   lut <- matrix(FALSE, length(corrQ), length(hypoQ))
   lut[cbind(seq_along(corrQ),corrQ)] <- TRUE
 
   ifft_scale <- M$xstep*M$ystep/(4*pres^2)
   Mpad <- matrix(0, ncol=2*pres, nrow=2*pres)
   Mpad[1:pres, 1:pres] <- inside
-  fM <- fft2d(Mpad)
+  fM <- fft2d(Mpad, fftw=use_fftw)
   
   qhz <- rep(NA,pres^2)
   if(verbose) pb <- txtProgressBar(0,length(hypoQ),style=3)
   for(i in 1:length(hypocen)){
     fK <- kernel2d_fft(hypoQ[i], M$xstep, M$ystep, pres)
 
-    con <- fft2d(fM*fK,inverse=TRUE)[1:pres,1:pres]
+    con <- fft2d(fM*fK,inverse=TRUE,fftw=use_fftw)[1:pres,1:pres]
     qhz[lut[,i]] <- Mod(con[lut[,i]])*ifft_scale
     if(verbose) setTxtProgressBar(pb,i)
   }

--- a/R/edgeh.R
+++ b/R/edgeh.R
@@ -20,14 +20,14 @@ edgeh <- function(bwim,pres,tres,step,W,verbose=FALSE){
   ifft_scale <- M$xstep*M$ystep/(4*pres^2)
   Mpad <- matrix(0, ncol=2*pres, nrow=2*pres)
   Mpad[1:pres, 1:pres] <- inside
-  fM <- fft(Mpad)
+  fM <- fft2d(Mpad)
   
   qhz <- rep(NA,pres^2)
   if(verbose) pb <- txtProgressBar(0,length(hypoQ),style=3)
   for(i in 1:length(hypocen)){
     fK <- kernel2d_fft(hypoQ[i], M$xstep, M$ystep, pres)
 
-    con <- fft(fM*fK,inverse=TRUE)[1:pres,1:pres]
+    con <- fft2d(fM*fK,inverse=TRUE)[1:pres,1:pres]
     qhz[lut[,i]] <- Mod(con[lut[,i]])*ifft_scale
     if(verbose) setTxtProgressBar(pb,i)
   }

--- a/R/fft.R
+++ b/R/fft.R
@@ -1,0 +1,15 @@
+#' 2D Fast fourier wrapper around fftwtools or stats package
+#' 
+#' Utilises the Fastest fourier transform in the West via the fftwtools
+#' package if available
+#' 
+#' @param x the data to transform
+#' @param inverse whether it should compute the inverse transform (defaults to FALSE)
+#' @return the fast fourier (inverse) transform of the same size as x, but complex.
+fft2d <- function(x, inverse=FALSE) {
+  if (requireNamespace("fftwtools", quietly=TRUE)) {
+    fftwtools::fftw2d(data=x, inverse=inverse)
+  } else {
+    stats::fft(z=x, inverse=inverse)
+  }
+}

--- a/R/fft.R
+++ b/R/fft.R
@@ -5,11 +5,16 @@
 #' 
 #' @param x the data to transform
 #' @param inverse whether it should compute the inverse transform (defaults to FALSE)
+#' @param fftw whether fftwtools package is available.
 #' @return the fast fourier (inverse) transform of the same size as x, but complex.
-fft2d <- function(x, inverse=FALSE) {
-  if (requireNamespace("fftwtools", quietly=TRUE)) {
+fft2d <- function(x, inverse=FALSE, fftw = fftw_available()) {
+  if (fftw) {
     fftwtools::fftw2d(data=x, inverse=inverse)
   } else {
     stats::fft(z=x, inverse=inverse)
   }
+}
+
+fftw_available <- function() {
+  requireNamespace("fftwtools", quietly=TRUE)
 }


### PR DESCRIPTION
Around 30-35% speedup with this. This is utilising as a suggests (rather than depends) the fftwtools package which provides the 2d version of FFT from the FFTW library.

fftwtools does not currently provide an interface to the 3D FFT. I might look at adding that to the fftwtools package so we're prepared for speeding up multiscale (and for spatiotemporal as well).

I've used suggests rather than depends, as the package works fine without fftwtools being installed: It's just faster if it is there. Also only used if FFT is used ofcourse. So you may want to add some notes to the documentation perhaps?