### PR TITLE
Update DESCRIPTION and rebuild site

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,3 +14,5 @@ License: GPL (>= 2)
 LazyLoad: yes
 NeedsCompilation: no
 RoxygenNote: 6.0.1
+URL: http://tilmandavies.github.io/sparr, https://github.com/tilmandavies/sparr
+BugReports: https://github.com/tilmandavies/sparr/issues


### PR DESCRIPTION
Once you merge this in, make sure you rebuild sparr (so you have the cat->message changes) then rerun pkgdown::build_site() to build the website. That should get the messages turned off in the examples.